### PR TITLE
Ensure that spark line is still drawn if all values are 0

### DIFF
--- a/spark-line.js
+++ b/spark-line.js
@@ -77,7 +77,8 @@ class Sparkline extends HTMLElement {
 		canvas.tabIndex = 0
 
 		let ctx = canvas.getContext("2d")
-		let max = Math.max.apply(Math, values)
+		// If the max is zero -- i.e. all values are 0 we don't want to divide-by-zero.
+		let max = Math.max.apply(Math, values) || 1;
 		let xStep = (this.width - this.lineWidth * 2) / (values.length - 1)
 		let yStep = (this.height - this.lineWidth * 3) / max
 


### PR DESCRIPTION
Otherwise we try to divide by zero which ends up giving us Infinity, and then anything divided by Infinity = 0 (at least in JS)

Simple repro case:

```html
                  <spark-line curve="false" values="0 0 0 0"></spark-line>
```

@chrisburnell
